### PR TITLE
Feat: Implement PlaceList.vue, PlaceDetail.vue and integrate with testServer.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite App</title>
+      <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=VITE_KAKAO_APP_KEY&libraries=services,clusterer,drawing"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/src/components/KakaoMap.vue
+++ b/src/components/KakaoMap.vue
@@ -3,9 +3,8 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from 'vue';
+import { ref, watch } from 'vue';
 
-// 1. 부모 컴포넌트로부터 주소(address)를 전달받기 위한 props 정의
 const props = defineProps({
   address: {
     type: String,
@@ -15,7 +14,6 @@ const props = defineProps({
 
 const container = ref(null); // 지도를 담을 ref
 
-// ✅ loadMap을 먼저 정의
 const loadMap = (address) => {
   if (window.kakao && window.kakao.maps) {
     window.kakao.maps.load(() => {

--- a/src/components/KakaoMap.vue
+++ b/src/components/KakaoMap.vue
@@ -1,0 +1,67 @@
+<template>
+  <div ref="container" class="map-container"></div>
+</template>
+
+<script setup>
+import { ref, onMounted, watch } from 'vue';
+
+// 1. 부모 컴포넌트로부터 주소(address)를 전달받기 위한 props 정의
+const props = defineProps({
+  address: {
+    type: String,
+    required: true,
+  },
+});
+
+const container = ref(null); // 지도를 담을 ref
+
+// ✅ loadMap을 먼저 정의
+const loadMap = (address) => {
+  if (window.kakao && window.kakao.maps) {
+    window.kakao.maps.load(() => {
+      const geocoder = new window.kakao.maps.services.Geocoder();
+
+      geocoder.addressSearch(address, (result, status) => {
+        if (status === window.kakao.maps.services.Status.OK && container.value) {
+          const coords = new window.kakao.maps.LatLng(result[0].y, result[0].x);
+          const options = {
+            center: coords,
+            level: 3,
+          };
+          const map = new window.kakao.maps.Map(container.value, options);
+          new window.kakao.maps.Marker({
+            map: map,
+            position: coords,
+          });
+        }
+      });
+    });
+  } else {
+    console.error("카카오맵 API 스크립트가 로드되지 않았습니다.");
+    const apiKey = import.meta.env.VITE_API_KEY;
+    console.log('로드된 API 키:', apiKey);
+  }
+};
+
+
+watch(
+  () => props.address,
+  (newAddress) => {
+    if (newAddress) {
+      loadMap(newAddress);
+    }
+  },
+  { immediate: true }
+);
+</script>
+
+<style scoped>
+.map-container {
+  width: 100%;
+  height: 200px;
+  border-radius: 0.75rem;
+  position: static;
+  z-index: 0;
+  overflow: hidden;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -2,15 +2,31 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 
 import App from './App.vue';
-
-import './assets/fonts/fonts.css'    // fonts.css 등록 (경로 src/assets/fonts/fonts.css)
-import 'bootstrap';
-import 'bootstrap/dist/css/bootstrap.min.css';
 import router from './router';
 
-const app = createApp(App);
+import './assets/fonts/fonts.css';
+import 'bootstrap';
+import 'bootstrap/dist/css/bootstrap.min.css';
 
-app.use(createPinia());
-app.use(router);
+// .env 파일에서 카카오 앱 키 가져오기
+const KAKAO_APP_KEY = import.meta.env.VITE_KAKAO_APP_KEY;
 
-app.mount('#app');
+// 카카오맵 SDK 동적 로드 스크립트
+const script = document.createElement('script');
+/* global kakao */
+script.onload = () => {
+  // SDK 로드가 완료되면 kakao.maps.load를 통해 init 함수 실행
+  kakao.maps.load(init);
+};
+script.src = `//dapi.kakao.com/v2/maps/sdk.js?autoload=false&appkey=${KAKAO_APP_KEY}&libraries=services,clusterer,drawing`;
+document.head.appendChild(script);
+
+
+function init() {
+
+  const app = createApp(App);
+
+  app.use(createPinia());
+  app.use(router);
+  app.mount('#app');
+}

--- a/src/pages/place/PlaceDetail.vue
+++ b/src/pages/place/PlaceDetail.vue
@@ -6,10 +6,12 @@
       </header>
       <div class="container">
         <div class="content">
+          <!-- <img :src="spot.image" :alt="spot.name" class="spot-image" /> -->
           <img
             :src="place.image"
             alt="장소 이미지"
             style="border-radius: 0.75rem"
+            class="spot-image"
           />
           <div class="infoItem_wrap" style="margin-top: 0.375rem">
             <div v-if="place.isBarrierFree == true">
@@ -53,24 +55,42 @@
     <p style="font-size: 50px">데이터를 불러올 수 없음</p>
   </div>
 </template>
+
+
 <script setup>
-import axios from 'axios';
-import { onMounted, ref } from 'vue';
-import no_barrier from '@/assets/img/no_barrier_free.png';
-import yes_barrier from '@/assets/img/yes_barrier_free.png';
+  import axios from 'axios';
+  import { onMounted, ref } from 'vue';
+  import { useRoute } from 'vue-router'; 
+  import no_barrier from '@/assets/img/no_barrier_free.png';
+  import yes_barrier from '@/assets/img/yes_barrier_free.png';
 
-const testId = 1;
-const place = ref(null);
+  const route = useRoute(); 
+  const place = ref(null);
 
-onMounted(async () => {
-  try {
-    const res = await axios.get(`http://localhost:3000/places?id=${testId}`);
-    place.value = res.data[0];
-  } catch (error) {
-    console.error('에러', error);
-  }
-});
+  // 현재 장소 ID 가져오기
+  const placeId = parseInt(route.params.id);
+
+  onMounted(async () => {
+    try {
+    // api연결 전/ testServer.json 파일에 GET 요청
+      const response = await axios.get('/testServer.json'); 
+      const allPlaces = response.data.places;
+
+      // ID가 일치하는 장소 찾기
+      place.value = allPlaces.find(p => p.id === placeId);
+
+      // 만약 일치하는 장소 없을시 콘솔에 오류 메시지
+      if (!place.value) {
+        console.error(`ID '${placeId}'에 해당하는 장소를 찾을 수 없습니다.`);
+      }
+
+    } catch (error) {
+      console.error('데이터를 불러오는 중 에러 발생:', error);
+    }
+  });
 </script>
+
+
 <style scoped>
 * {
   margin: 0;
@@ -79,11 +99,13 @@ onMounted(async () => {
   line-height: 1;
   letter-spacing: -0.03rem;
 }
+
 header {
   font-size: 2rem;
   padding-top: 2.03125rem;
   padding-bottom: 1.03125rem;
 }
+
 button {
   width: 160px;
   height: 50px;
@@ -93,6 +115,7 @@ button {
   font-size: 1.25rem;
   font-weight: bold;
 }
+
 /* class */
 .wrap {
   width: 360px;
@@ -103,6 +126,7 @@ button {
   display: flex;
   background-color: #f6f6f6;
 }
+
 .container {
   width: 330px;
   height: 582px;
@@ -110,11 +134,13 @@ button {
   background-color: #ffffff;
   padding-top: 0.625rem;
 }
+
 .content {
   display: flex;
   flex-direction: column;
   align-items: center;
 }
+
 .infoItem_wrap {
   display: flex;
   padding: 0 0.9375rem;
@@ -123,6 +149,7 @@ button {
   align-items: center;
   margin-bottom: 0.3125rem;
 }
+
 .border {
   display: flex;
   width: 70px;
@@ -135,22 +162,34 @@ button {
   justify-content: center;
   align-items: center;
 }
+
 .isBarrierImg {
   width: 290px;
   height: 35px;
 }
+
 /* 스크롤바 */
 .description_wrap {
   height: 220px;
   overflow-y: auto;
 }
+
 .description_wrap::-webkit-scrollbar {
   display: none;
 }
+
 .place_name {
   flex: 1;
   font-size: 0.875rem;
 }
+
+.spot-image {
+  width: 95%;
+  max-width: 330px;
+  object-fit: cover;
+  display: block;
+}
+
 .btn_wrap {
   display: flex;
   width: 330px;

--- a/src/pages/place/PlaceDetail.vue
+++ b/src/pages/place/PlaceDetail.vue
@@ -23,7 +23,7 @@
           </div>
           <div class="description_wrap">
             <div class="infoItem_wrap">
-              <div class="border"><p>장소</p></div>
+              <div class="border"><p>주소</p></div>
               <div class="place_name">{{ place.address }}</div>
             </div>
             <div class="infoItem_wrap">
@@ -93,14 +93,15 @@
 
 <style scoped>
 * {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
-  font-weight: bold;
   line-height: 1;
   letter-spacing: -0.03rem;
 }
 
 header {
+  font-family: 'Font-Bold';
   font-size: 2rem;
   padding-top: 2.03125rem;
   padding-bottom: 1.03125rem;
@@ -112,12 +113,13 @@ button {
   border: 0.0625rem solid #7d828d;
   border-radius: 0.75rem;
   background-color: #ffffff;
+  font-family: 'Font-Medium';
   font-size: 1.25rem;
-  font-weight: bold;
 }
 
 /* class */
 .wrap {
+  position: relative;
   width: 360px;
   height: 740px;
   margin: 0 auto;
@@ -129,16 +131,24 @@ button {
 
 .container {
   width: 330px;
-  height: 582px;
+  min-height: 580px;
   border-radius: 0.625rem;
   background-color: #ffffff;
   padding-top: 0.625rem;
+  overflow-y: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.container::-webkit-scrollbar {
+  display: none;
 }
 
 .content {
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-bottom: 80px;
 }
 
 .infoItem_wrap {
@@ -157,8 +167,8 @@ button {
   margin-right: 0.75rem;
   border-radius: 0.75rem;
   background-color: #d9d9d9;
+  font-family: "Font-Bold";
   font-size: 1rem;
-  font-weight: bold;
   justify-content: center;
   align-items: center;
 }
@@ -168,19 +178,10 @@ button {
   height: 35px;
 }
 
-/* 스크롤바 */
-.description_wrap {
-  height: 220px;
-  overflow-y: auto;
-}
-
-.description_wrap::-webkit-scrollbar {
-  display: none;
-}
-
 .place_name {
   flex: 1;
-  font-size: 0.875rem;
+  font-family: 'Font-Medium';
+  font-size: 1rem;
 }
 
 .spot-image {
@@ -191,10 +192,13 @@ button {
 }
 
 .btn_wrap {
+  position: absolute;
+  bottom: 15px;
+  left: 50%; 
+  transform: translateX(-50%);
   display: flex;
   width: 330px;
   height: 50px;
-  margin-top: 1rem;
   justify-content: space-between;
 }
 </style>

--- a/src/pages/place/PlaceDetail.vue
+++ b/src/pages/place/PlaceDetail.vue
@@ -42,7 +42,11 @@
               <div class="border"><p>설명</p></div>
               <div class="place_name">{{ place.description }}</div>
             </div>
+            <div class="map_wrap">
+             <KakaoMap :address="place.address" />
+            </div>
           </div>
+
           <div class="btn_wrap">
             <button class="sound_btn">음성 해설</button>
             <button class="add_btn">일정에 추가</button>
@@ -58,6 +62,7 @@
 
 
 <script setup>
+  import KakaoMap from '@/components/KakaoMap.vue';   
   import axios from 'axios';
   import { onMounted, ref } from 'vue';
   import { useRoute } from 'vue-router'; 
@@ -155,7 +160,8 @@ button {
   display: flex;
   padding: 0 0.9375rem;
   width: 330px;
-  height: 35px;
+  min-height: 35px;
+  height: auto;
   align-items: center;
   margin-bottom: 0.3125rem;
 }
@@ -191,6 +197,14 @@ button {
   display: block;
 }
 
+/* kakaomap지도 */
+.map_wrap {
+  width: 95%;
+  margin: 1rem auto 0;
+  position: relative;
+
+}
+
 .btn_wrap {
   position: absolute;
   bottom: 15px;
@@ -200,5 +214,6 @@ button {
   width: 330px;
   height: 50px;
   justify-content: space-between;
+  background-color: #ffffff;
 }
 </style>

--- a/src/pages/place/PlaceList.vue
+++ b/src/pages/place/PlaceList.vue
@@ -235,11 +235,3 @@ const confirmSelection = () => {
   background-color: #9c1571;
 }
 </style>
-
-<!-- <template>
-  <router-link :to="`/place/${place.id}`">
-    <button>자세히 보기</button>
-  </router-link>
-</template>
-<script setup></script>
-<style scoped></style> -->

--- a/src/pages/place/PlaceList.vue
+++ b/src/pages/place/PlaceList.vue
@@ -26,7 +26,6 @@
           <img :src="spot.image" :alt="spot.name" class="spot-image" />
           <div class="card-content">
             <h3 class="spot-title">{{ spot.name }}</h3>
-            <p class="spot-description">{{ spot.description }}</p>
             <div class="tag-container">
               <span v-for="tag in spot.tags" :key="tag" class="tag">
                 #{{ tag }}
@@ -116,6 +115,7 @@ const confirmSelection = () => {
 }
 .header_logo {
   padding-top: 2rem;
+  padding-bottom: 0.5rem;
   width: 15rem;
   display: block;
   margin: 0 auto;
@@ -143,7 +143,6 @@ const confirmSelection = () => {
   font-family: 'Font-Medium';
   font-size: 1rem;
   color: #000000;
-  margin-top: 0.5rem;
 }
 
 /* 추천 관광지 카드 리스트 */
@@ -181,8 +180,8 @@ const confirmSelection = () => {
   font-size: 1.125rem; 
 }
 .spot-description {
-  font-family: 'Font-Regular';
-  font-size: 0.875rem; 
+  font-family: 'Font-Medium';
+  font-size: 1rem; 
   color: #555;
   margin-top: 0.25rem;
 }

--- a/src/pages/place/PlaceList.vue
+++ b/src/pages/place/PlaceList.vue
@@ -44,9 +44,9 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'; // onMounted 추가
+import { ref, onMounted } from 'vue'; 
 import { useRouter } from 'vue-router';
-import axios from 'axios'; // axios import
+import axios from 'axios'; 
 
 const router = useRouter();
 
@@ -111,7 +111,7 @@ const confirmSelection = () => {
   display: flex;
   flex-direction: column;
   background-color: #f6f6f6;
-  position: relative; /* 버튼 위치 기준점 */
+  position: relative;
 }
 .header_logo {
   padding-top: 2rem;

--- a/src/pages/place/PlaceList.vue
+++ b/src/pages/place/PlaceList.vue
@@ -1,7 +1,246 @@
 <template>
+  <div class="wrap">
+    <header>
+      <img
+        src="@/assets/img/seniorway_logo.png"
+        alt="SENIORWAY Logo"
+        class="header_logo"
+      />
+    </header>
+
+    <div class="container">
+      <div class="title-wrap">
+        <p class="subtitle">
+          마음에 드는 장소를 모두 선택하여<br/>나만의 여행 일정을 만들어보세요!
+        </p>
+      </div>
+
+      <div class="recommendation-list">
+        <div
+          v-for="spot in recommendedSpots"
+          :key="spot.id"
+          class="spot-card"
+          :class="{ selected: selectedSpots.includes(spot.id) }"
+          @click="toggleSelection(spot.id)"
+        >
+          <img :src="spot.image" :alt="spot.name" class="spot-image" />
+          <div class="card-content">
+            <h3 class="spot-title">{{ spot.name }}</h3>
+            <p class="spot-description">{{ spot.description }}</p>
+            <div class="tag-container">
+              <span v-for="tag in spot.tags" :key="tag" class="tag">
+                #{{ tag }}
+              </span>
+            </div>
+            <div class="card-footer">
+              <a href="#" @click.stop="goToDetail(spot.id)">자세히 보기</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <button class="btn-confirm" @click="confirmSelection">선택 완료</button>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'; // onMounted 추가
+import { useRouter } from 'vue-router';
+import axios from 'axios'; // axios import
+
+const router = useRouter();
+
+// 최종 선택된 관광지 ID 저장 배열
+const selectedSpots = ref([]);
+
+// 데이터 받아올 변수
+const recommendedSpots = ref([]);
+
+// 데이터를 불러오는 함수
+const fetchRecommendations = async () => {
+  try {
+    // api연결 전/ testServer.json 파일에 GET 요청
+    const response = await axios.get('/testServer.json');
+    recommendedSpots.value = response.data.places;
+  } catch (error) {
+    console.error('추천 데이터를 불러오는 데 실패했습니다:', error);
+  }
+};
+
+onMounted(() => {
+  fetchRecommendations();
+});
+
+// 관광지 선택/해제 함수
+const toggleSelection = (spotId) => {
+  const index = selectedSpots.value.indexOf(spotId);
+  if (index > -1) {
+    selectedSpots.value.splice(index, 1);
+  } else {
+    selectedSpots.value.push(spotId);
+  }
+};
+
+// 자세히 보기 페이지로 이동
+const goToDetail = (spotId) => {
+  router.push(`/place/${spotId}`);
+};
+
+// 선택 완료 버튼 클릭 함수
+const confirmSelection = () => {
+  if (selectedSpots.value.length === 0) {
+    alert('1개 이상의 장소를 선택해주세요.');
+    return;
+  }
+  console.log('최종 선택된 장소 ID:', selectedSpots.value);
+};
+</script>
+
+<style scoped>
+* {
+  margin: 0;
+  padding: 0;
+  line-height: 1.2;
+  letter-spacing: -0.03rem;
+  box-sizing: border-box;
+}
+.wrap {
+  width: 360px;
+  height: 740px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  background-color: #f6f6f6;
+  position: relative; /* 버튼 위치 기준점 */
+}
+.header_logo {
+  padding-top: 2rem;
+  width: 15rem;
+  display: block;
+  margin: 0 auto;
+}
+.container {
+  flex-grow: 1;
+  padding: 0 1.25rem;
+  overflow-y: auto; /* 스크롤 */
+  margin-bottom: 5rem; 
+}
+.highlight {
+  color: #b71a86;
+}
+
+/* 페이지 제목 */
+.title-wrap {
+  text-align: center;
+  margin: 1.5rem 0 2rem 0;
+}
+.main-title {
+  font-family: 'Font-Bold';
+  font-size: 1.5rem; 
+}
+.subtitle {
+  font-family: 'Font-Medium';
+  font-size: 1rem;
+  color: #000000;
+  margin-top: 0.5rem;
+}
+
+/* 추천 관광지 카드 리스트 */
+.recommendation-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* 개별 카드 */
+.spot-card {
+  background-color: #ffffff;
+  border-radius: 0.75rem;
+  border: 2px solid transparent; 
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+  cursor: pointer;
+  position: relative;
+  transition: border-color 0.2s;
+}
+.spot-card.selected {
+  border-color: #b71a86;
+}
+.spot-image {
+  width: 100%;
+  height: 150px;
+  object-fit: cover;
+  display: block;
+}
+.card-content {
+  padding: 1rem;
+}
+.spot-title {
+  font-family: 'Font-Bold';
+  font-size: 1.125rem; 
+}
+.spot-description {
+  font-family: 'Font-Regular';
+  font-size: 0.875rem; 
+  color: #555;
+  margin-top: 0.25rem;
+}
+
+/* 태그 */
+.tag-container {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem; 
+}
+.tag {
+  font-family: 'Font-Medium';
+  font-size: 0.75rem; 
+  background-color: #f0f0f0;
+  color: #555;
+  padding: 0.25rem 0.5rem;
+  border-radius: 1rem;
+}
+
+/* 자세히 보기 */
+.card-footer {
+  text-align: right;
+  margin-top: 1rem;
+}
+.card-footer a {
+  font-family: 'Font-Medium';
+  font-size: 0.875rem;
+  color: #7d828d;
+  text-decoration: underline;
+}
+
+/* 선택 완료 버튼 */
+.btn-confirm {
+  position: absolute; 
+  bottom: 2rem;
+  right: 1.5rem;
+  width: 100px;
+  height: 50px;
+  border-radius: 25px; /* 타원형 */
+  border: none;
+  background-color: #b71a86;
+  color: white;
+  font-family: 'Font-Bold';
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  transition: background-color 0.2s;
+}
+.btn-confirm:hover {
+  background-color: #9c1571;
+}
+</style>
+
+<!-- <template>
   <router-link :to="`/place/${place.id}`">
     <button>자세히 보기</button>
   </router-link>
 </template>
 <script setup></script>
-<style scoped></style>
+<style scoped></style> -->

--- a/testServer.json
+++ b/testServer.json
@@ -13,13 +13,14 @@
     {
       "id": 1,
       "name": "보수동 책방골목",
-      "image": "https://loremflickr.com/300/300/cat",
+      "image": "https://storage.doopedia.co.kr/upload/_upload/image5/travel/editor/2020/06/13/20200613221422441_thumb.jpg",
       "address": "부산광역시 중구 보수동 1가",
       "openingHours": "오전 10:00 ~ 오후 8:30",
       "holiday": "없음",
       "price": "없음",
       "description": "부산광역시 중구에 위치한 명소. 여러 종류의 고서, 동양학, 소설, 외국원서, 만화, 잡지, 교과서, 헌책 등 각 서점이 전문적으로 운영되고 있다.",
-      "isBarrierFree": true
+      "isBarrierFree": true,
+      "tags": ["역사·문화·예술", "실내", "휠체어"]
     },
     {
       "id": 2,
@@ -30,7 +31,8 @@
       "holiday": "없음",
       "price": "없음",
       "description": "침대가 있다.",
-      "isBarrierFree": false
+      "isBarrierFree": false,
+      "tags": ["역사·문화·예술", "야외"]
     }
   ],
   "profile": [

--- a/testServer.json
+++ b/testServer.json
@@ -18,7 +18,7 @@
       "openingHours": "오전 10:00 ~ 오후 8:30",
       "holiday": "없음",
       "price": "없음",
-      "description": "부산광역시 중구에 위치한 명소. 여러 종류의 고서, 동양학, 소설, 외국원서, 만화, 잡지, 교과서, 헌책 등 각 서점이 전문적으로 운영되고 있다.",
+      "description": "부산광역시 중구에 위치한 명소. 여러 종류의 고서, 동양학, 소설, 외국원서, 만화, 잡지, 교과서, 헌책 등 각 서점이 전문적으로 운영되고 있다. Lorem ipsum dolor sit amet consectetur adipisicing elit. Accusamus molestias quasi voluptatum obcaecati magnam. Vel, quos ipsam! Eius sint, quis vel placeat veniam modi dolore amet non accusamus?",
       "isBarrierFree": true,
       "tags": ["역사·문화·예술", "실내", "휠체어"]
     },


### PR DESCRIPTION
**1. PlaceList.vue 페이지 구현**
<img src="https://github.com/user-attachments/assets/209ef25f-b57a-48a1-8772-618f4f00434c" width="200" />

  - 기존 Figma에서의 디자인과 상이하게 구현
  - 다중 선택 가능
  - 선택된 place의 테두리는 컬러 border처리되도록 하였음
  - 현재는 testServer.json 파일에서 불러온 데이터로 띄우고 있음
  - 추후 자세히보기/선택완료 버튼 시각적으로 잘 보이도록 수정 _예정_


**2. PlaceDetail.vue 페이지 style 수정**
  - 현재는 testServer.json 파일에서 불러온 데이터로 띄우고 있음

**3. PlaceDetail.vue 페이지 하단에 카카오맵 추가**
<img src="https://github.com/user-attachments/assets/01d97ab8-9e27-4724-8d23-4534787ab4c6" width="200" /><img src="https://github.com/user-attachments/assets/e2de2d93-fa22-474e-b4d4-c943106937c3" width="200" />

  3.1. KakaoMap.vue 컴포넌트 생성
      - 추후 Map을 불러와서 사용하는 기능이 추가될 것을 고려하여 Component로 생성하였음
   3.2 PlaceDetail.vue 하단에 해당 주소가 pin으로 찍힌 카카오맵 추가
      - .env 파일의 API 키를 안전하게 사용하기 위해 동적 스크립트 로딩 방식 적용
      - 지도 축소.확대 가능한 상태
      - 추후 하단의 footer(버튼) 뒤로 다른 요소 보이지 않도록 수정 _예정_
      - 음성 해설/일정 추가 버튼 기능은 나중에 해당 페이지 구현 후 연결 _예정_